### PR TITLE
ZMX-#22 fixed mapping the wrong port. Bug resolved

### DIFF
--- a/src/main/java/dev/message/MessageBuilder.java
+++ b/src/main/java/dev/message/MessageBuilder.java
@@ -10,12 +10,12 @@ import java.util.UUID;
 
 public class MessageBuilder {
 
-    public static Message buildHandshakeMessage(String senderPublicKeyEncoded) {
+    public static Message buildHandshakeMessage(String senderPublicKeyEncoded, int port) {
         return new Message(
                 MessageType.HANDSHAKE,
                 System.currentTimeMillis(),
                 UUID.randomUUID().toString(),
-                new HandshakePayload(senderPublicKeyEncoded)
+                new HandshakePayload(senderPublicKeyEncoded, port)
         );
     }
 

--- a/src/main/java/dev/message/MessageSerializer.java
+++ b/src/main/java/dev/message/MessageSerializer.java
@@ -5,6 +5,7 @@ import dev.models.enums.MessageType;
 import dev.models.Message;
 import dev.models.PeerInfo;
 import dev.utils.CustomException;
+import dev.utils.Logger;
 
 import java.util.List;
 import java.util.UUID;
@@ -26,7 +27,7 @@ public class MessageSerializer {
             case HANDSHAKE -> {
                 if (!(payload instanceof HandshakePayload hp))
                     throw new CustomException("Expected HandshakePayload", null);
-                return hp.getPublicKeyBase64Encoded();
+                return hp.getPublicKeyBase64Encoded() + ":" + hp.getPort();
             }
 
             case PEER_DISCOVERY_REQUEST -> {
@@ -96,7 +97,8 @@ public class MessageSerializer {
         switch (messageType) {
 
             case HANDSHAKE -> {
-                return new HandshakePayload(rawPayload);
+                String[] parts = rawPayload.split(":");
+                return new HandshakePayload(parts[0], Integer.parseInt(parts[1]));
             }
 
             case PEER_DISCOVERY_REQUEST -> {

--- a/src/main/java/dev/message/payload/HandshakePayload.java
+++ b/src/main/java/dev/message/payload/HandshakePayload.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class HandshakePayload extends MessagePayload {
     private final String publicKeyBase64Encoded; // Base64 encoded public key
+    private final int port;
 }

--- a/src/main/java/dev/network/NetworkManager.java
+++ b/src/main/java/dev/network/NetworkManager.java
@@ -154,6 +154,10 @@ public class NetworkManager {
         knownPeers.remove(peerInfo);
     }
 
+    public int getPort() {
+        return config.getNodePort();
+    }
+
     private void registerProtocols() {
         messageHandler.registerProtocol(MessageType.PEER_DISCOVERY_REQUEST, peerDiscoveryProtocol);
         messageHandler.registerProtocol(MessageType.PEER_DISCOVERY_RESPONSE, peerDiscoveryProtocol);

--- a/src/main/java/dev/network/Peer.java
+++ b/src/main/java/dev/network/Peer.java
@@ -29,7 +29,7 @@ public class Peer implements Runnable {
     @Getter
     private final String ip;
     @Getter
-    private final int port;
+    private int port;
     private final NetworkManager networkManager;
     private final MessageQueue messageQueue;
     private final BufferedReader in;
@@ -48,7 +48,6 @@ public class Peer implements Runnable {
         this.socket = socket;
         this.peerDirection = peerDirection;
         this.ip = socket.getLocalAddress().getHostAddress();
-        this.port = socket.getPort();
         this.networkManager = networkManager;
         this.messageQueue = queue;
 
@@ -123,9 +122,9 @@ public class Peer implements Runnable {
     }
 
     private void sendHandshake() {
-        Message handshakeMessage = MessageBuilder.buildHandshakeMessage(networkManager.getEncodedPublicKey());
+        Message handshakeMessage = MessageBuilder.buildHandshakeMessage(networkManager.getEncodedPublicKey(), networkManager.getPort());
         this.send(handshakeMessage);
-        logger.info("Sent handshake to {}", socket.getRemoteSocketAddress());
+        logger.info("Sent handshake to {}:{}", getIp(), getPort());
     }
 
     private boolean waitForHandshakeResponse() throws Exception {
@@ -156,6 +155,7 @@ public class Peer implements Runnable {
         X509EncodedKeySpec keySpec = new X509EncodedKeySpec(publicKeyBytes);
         KeyFactory keyFactory = KeyFactory.getInstance("EC"); // TODO: Use config for algorithm
         this.publicKey = keyFactory.generatePublic(keySpec);
+        this.port = handshakePayload.getPort();
 
         socket.setSoTimeout(0);
         logger.info("Received handshake from {}", this.peerId);


### PR DESCRIPTION
Since port cannot be determined from the socket, it is included in the handshake request.

This way, all nodes exchange the port between themselves, so they are all up to date.

Bug resolved. Circuit created! 

Cheers :)